### PR TITLE
Modrules: explicit `allowGroundUnitGravity`

### DIFF
--- a/Gamedata/modrules.lua
+++ b/Gamedata/modrules.lua
@@ -14,6 +14,7 @@ local modrules  = {
     allowPushingEnemyUnits   = true; -- defaults to false
     allowCrushingAlliedUnits = false; -- defaults to false
     allowUnitCollisionDamage = true; -- defaults to false
+    allowGroundUnitGravity = true;
   },
   
   construction = {


### PR DESCRIPTION
This is already the implicit value, because it's the engine default. So there is no logic change, just safety against engine changes.